### PR TITLE
Refactor universe to PG class with rule-based actions

### DIFF
--- a/src/sim/pg/PG.js
+++ b/src/sim/pg/PG.js
@@ -1,20 +1,25 @@
 import { reactive } from 'vue'
 
 export class PG {
-    constructor(name, cfg, startTime) {
+    constructor(name, cfg, logFn) {
         this.name = name
         this.cfg = cfg
+        this.log = logFn
         this.state = reactive({
             needs: { energy: 95, nutrition: 85, hygiene: 80, social: 75, fun: 80 },
             activity: { name: 'Idle', until: null },
-            meta: { lastMeal: null, lastSleep: null, lastWash: null },
+            meta: { lastMealTime: null, lastSleepTime: null, lastShowerTime: null },
         })
-        this.time = startTime
     }
 
-    tickMinute(currentTime) {
-        this.time = currentTime
-        // Per ora solo decadimento base
+    schedule(currentTime, name, minutes) {
+        const until = new Date(currentTime.getTime() + minutes * 60000)
+        this.state.activity = { name, until }
+        if (this.log) this.log(`Inizio ${name} (${minutes}m)`)
+        return until
+    }
+
+    decayMinute() {
         const d = this.cfg.decay
         this.state.needs.energy -= d.energy.base / 60
         this.state.needs.nutrition -= d.nutrition / 60
@@ -28,5 +33,42 @@ export class PG {
         for (const k of Object.keys(this.state.needs)) {
             this.state.needs[k] = Math.max(0, Math.min(100, this.state.needs[k]))
         }
+    }
+
+    applyActivityMinute(currentTime) {
+        const a = this.state.activity.name
+        switch (a) {
+            case 'Dormire':
+                this.state.needs.energy = Math.min(100, this.state.needs.energy + (12.5 / 60))
+                this.state.needs.nutrition -= (1.0 / 60)
+                break
+            case 'Power-nap':
+                this.state.needs.energy = Math.min(100, this.state.needs.energy + 0.5)
+                break
+            case 'Mangiare':
+                this.state.needs.nutrition = Math.min(100, this.state.needs.nutrition + (50 / 40))
+                break
+            case 'Lavarsi':
+                this.state.needs.hygiene = Math.min(100, this.state.needs.hygiene + (40 / 12))
+                break
+            case 'Socializzare':
+                this.state.needs.social = Math.min(100, this.state.needs.social + (35 / 90))
+                this.state.needs.fun = Math.min(100, this.state.needs.fun + (10 / 90))
+                this.state.needs.energy -= (1.0 / 60)
+                break
+            case 'Svago':
+                this.state.needs.fun = Math.min(100, this.state.needs.fun + (25 / 60))
+                break
+            case 'Lavorare':
+                this.state.needs.energy -= (4.0 / 60)
+                this.state.needs.nutrition -= (2.0 / 60)
+                break
+            case 'Idle':
+                this.state.needs.energy = Math.min(100, this.state.needs.energy + 0.2)
+                break
+        }
+        if (a !== 'Dormire') this.decayMinute()
+        else this.clampNeeds()
+        return new Date(currentTime.getTime() + 60000)
     }
 }

--- a/src/sim/universe/Universe.js
+++ b/src/sim/universe/Universe.js
@@ -2,20 +2,15 @@
 import { reactive } from 'vue'
 import { defaultConfig } from '../config/defaultConfig'
 import { PG } from '../pg/PG'
+import { handleSleep, handleWork, handleEmergencies, handleMeals, handleNap, handleSocial, handleFun, handleHygiene, handleIdle } from './rules'
 
 export function createUniverse() {
     const cfg = reactive(defaultConfig())
     const state = reactive({
         time: new Date(2025, 0, 1, cfg.time.startHour, 0, 0, 0),
         speed: 1, // 1x = realtime (1 minuto in game = 1 minuto reale)
-        needs: { energy: 95, nutrition: 85, hygiene: 80, social: 75, fun: 80 },
-        activity: { name: 'Idle', until: null },
+        pg: null,
         napCount: 0,
-        meta: {
-            lastMealTime: null,
-            lastSleepTime: null,
-            lastShowerTime: null,
-        },
         workingToday: true,
         running: false,
     })
@@ -27,11 +22,12 @@ export function createUniverse() {
         if (logs.length > 300) logs.shift()
     }
 
+    state.pg = new PG('PG', cfg, log)
+
     function reinit() {
 
         state.time = new Date(2025, 0, 1, cfg.time.startHour, 0, 0, 0)
-        state.needs = { energy: 95, nutrition: 85, hygiene: 80, social: 75, fun: 80 }
-        state.activity = { name: 'Idle', until: null }
+        state.pg = new PG('PG', cfg, log)
         state.napCount = 0
         state.workingToday = true
         logs.length = 0
@@ -65,24 +61,6 @@ export function createUniverse() {
         }, msPerMinute)
     }
 
-    // --- Decay & clamp ---
-    function decayMinute() {
-        const d = cfg.decay
-        // decadimento per minuto (valori base sono per ora)
-        state.needs.energy -= d.energy.base / 60
-        state.needs.nutrition -= d.nutrition / 60
-        state.needs.hygiene -= d.hygiene / 60
-        state.needs.social -= d.social / 60
-        state.needs.fun -= d.fun / 60
-        clampNeeds()
-    }
-
-    function clampNeeds() {
-        for (const k of Object.keys(state.needs)) {
-            state.needs[k] = Math.max(0, Math.min(100, state.needs[k]))
-        }
-    }
-
     function within(h, [a, b]) {
         return h >= a && h < b
     }
@@ -94,90 +72,50 @@ export function createUniverse() {
 
     // --- Main advance ---
     function advanceMinute() {
-        if (state.activity.until && state.time < state.activity.until) {
-            // Attività in corso
-            applyActivityMinute()
+        if (state.pg.state.activity.until && state.time < state.pg.state.activity.until) {
+            state.time = state.pg.applyActivityMinute(state.time)
             return
         }
 
-        // Fine attività
-        if (state.activity.until && state.time >= state.activity.until) {
-            log(`Fine ${state.activity.name}`)
-            state.activity = { name: 'Idle', until: null }
+        if (state.pg.state.activity.until && state.time >= state.pg.state.activity.until) {
+            log(`Fine ${state.pg.state.activity.name}`)
+            state.pg.state.activity = { name: 'Idle', until: null }
         }
 
-        const h = state.time.getHours()
-
-        // Sonno notturno
-        if (h >= 23 || h < 7 || (state.needs.energy < 20 && h >= 21)) {
-            doSleepNight()
-            return
+        const ctx = {
+            state,
+            cfg,
+            pg: state.pg,
+            within,
+            isWeekend,
+            doSleepNight,
+            doNap,
+            doEat,
+            doWash,
+            doSocial,
+            doFun,
+            doWork,
+            doIdle,
         }
 
-        // Lavoro 9–17 (feriali)
-        const workOn = cfg.work.on && !isWeekend()
-        if (workOn && h >= cfg.work.start && h < cfg.work.end) {
-            if (state.needs.energy < 20) return doNap(30)
-            if (state.needs.nutrition < 15) return doEat(45)
-            if (state.needs.hygiene < 15) return doWash(12)
-            return doWork(30)
+        const rules = [
+            handleSleep,
+            handleWork,
+            handleEmergencies,
+            handleMeals,
+            handleNap,
+            handleSocial,
+            handleFun,
+            handleHygiene,
+            handleIdle,
+        ]
+
+        for (const r of rules) {
+            if (r(ctx)) return
         }
-
-        // Emergenze
-        if (state.needs.energy < 20) return doNap(30)
-        if (state.needs.nutrition < 15) return doEat(45)
-        if (state.needs.hygiene < 15) return doWash(12)
-
-        // Pasti
-
-        if (within(h, cfg.meals.breakfast) ||
-            within(h, cfg.meals.lunch) ||
-            within(h, cfg.meals.dinner)) {
-
-            const need = 100 - state.needs.nutrition
-
-            if (need > 30) {
-                return doEat(40) //pasto completo
-            } else if (need > 15) {
-                return doEat(25) //pasto normale
-            } else if (need > 0) {
-                return doEat(10) //spuntino
-            }
-
-        }
-
-
-        // Pisolino diurno
-        if (state.needs.energy < cfg.thr.energy && state.napCount < cfg.limits.maxNapsPerDay) {
-            return doNap(20)
-        }
-
-        // Social
-        if ((isWeekend() || h >= 19) && state.needs.social < cfg.thr.social) {
-            return doSocial(90)
-        }
-
-        // Svago
-        if (state.needs.fun < cfg.thr.fun) {
-            return doFun(60)
-        }
-
-        // Igiene
-        if (state.needs.hygiene < cfg.thr.hygiene) {
-            return doWash(12)
-        }
-
-        // Idle
-        doIdle(5)
     }
 
     // --- Activities ---
-    function schedule(name, minutes) {
-        const until = new Date(state.time.getTime() + minutes * 60000)
-        state.activity = { name, until }
-        log(`Inizio ${name} (${minutes}m)`)
-    }
-
     function doSleepNight() {
         const h = state.time.getHours()
         const targetEnd = new Date(state.time)
@@ -188,53 +126,15 @@ export function createUniverse() {
             targetEnd.setHours(7, 0, 0, 0)
         }
         let minutes = Math.max(360, Math.min(540, (targetEnd - state.time) / 60000))
-        schedule('Dormire', minutes)
+        state.pg.schedule(state.time, 'Dormire', minutes)
     }
-    function doNap(minutes) { state.napCount++; schedule('Power-nap', minutes) }
-    function doEat(minutes) { schedule('Mangiare', minutes) }
-    function doWash(minutes) { schedule('Lavarsi', minutes) }
-    function doSocial(minutes) { schedule('Socializzare', minutes) }
-    function doFun(minutes) { schedule('Svago', minutes) }
-    function doWork(minutes) { schedule('Lavorare', minutes) }
-    function doIdle(minutes) { schedule('Idle', minutes) }
-
-    // --- Apply effects per minuto ---
-    function applyActivityMinute() {
-        const a = state.activity.name
-        switch (a) {
-            case 'Dormire':
-                state.needs.energy = Math.min(100, state.needs.energy + (12.5 / 60))
-                state.needs.nutrition -= (1.0 / 60)
-                break
-            case 'Power-nap':
-                state.needs.energy = Math.min(100, state.needs.energy + 0.5) // +0.5/min
-                break
-            case 'Mangiare':
-                state.needs.nutrition = Math.min(100, state.needs.nutrition + (50 / 40))
-                break
-            case 'Lavarsi':
-                state.needs.hygiene = Math.min(100, state.needs.hygiene + (40 / 12))
-                break
-            case 'Socializzare':
-                state.needs.social = Math.min(100, state.needs.social + (35 / 90))
-                state.needs.fun = Math.min(100, state.needs.fun + (10 / 90))
-                state.needs.energy -= (1.0 / 60)
-                break
-            case 'Svago':
-                state.needs.fun = Math.min(100, state.needs.fun + (25 / 60))
-                break
-            case 'Lavorare':
-                state.needs.energy -= (4.0 / 60)
-                state.needs.nutrition -= (2.0 / 60)
-                break
-            case 'Idle':
-                state.needs.energy = Math.min(100, state.needs.energy + 0.2) // Idle leggermente ristorativo
-                break
-        }
-        if (a !== 'Dormire') decayMinute()
-        else clampNeeds()
-        state.time = new Date(state.time.getTime() + 60000)
-    }
+    function doNap(minutes) { state.napCount++; state.pg.schedule(state.time, 'Power-nap', minutes) }
+    function doEat(minutes) { state.pg.schedule(state.time, 'Mangiare', minutes) }
+    function doWash(minutes) { state.pg.schedule(state.time, 'Lavarsi', minutes) }
+    function doSocial(minutes) { state.pg.schedule(state.time, 'Socializzare', minutes) }
+    function doFun(minutes) { state.pg.schedule(state.time, 'Svago', minutes) }
+    function doWork(minutes) { state.pg.schedule(state.time, 'Lavorare', minutes) }
+    function doIdle(minutes) { state.pg.schedule(state.time, 'Idle', minutes) }
 
     return { state, cfg, logs, play, pause, step, reinit, setSpeed }
 }

--- a/src/sim/universe/rules.js
+++ b/src/sim/universe/rules.js
@@ -1,0 +1,77 @@
+export function handleSleep({ state, pg, doSleepNight }) {
+    const h = state.time.getHours()
+    if (h >= 23 || h < 7 || (pg.state.needs.energy < 20 && h >= 21)) {
+        doSleepNight()
+        return true
+    }
+    return false
+}
+
+export function handleWork({ state, pg, cfg, doNap, doEat, doWash, doWork, isWeekend }) {
+    const h = state.time.getHours()
+    const workOn = cfg.work.on && !isWeekend()
+    if (workOn && h >= cfg.work.start && h < cfg.work.end) {
+        if (pg.state.needs.energy < 20) { doNap(30); return true }
+        if (pg.state.needs.nutrition < 15) { doEat(45); return true }
+        if (pg.state.needs.hygiene < 15) { doWash(12); return true }
+        doWork(30)
+        return true
+    }
+    return false
+}
+
+export function handleEmergencies({ pg, doNap, doEat, doWash }) {
+    if (pg.state.needs.energy < 20) { doNap(30); return true }
+    if (pg.state.needs.nutrition < 15) { doEat(45); return true }
+    if (pg.state.needs.hygiene < 15) { doWash(12); return true }
+    return false
+}
+
+export function handleMeals({ state, pg, cfg, doEat, within }) {
+    const h = state.time.getHours()
+    if (within(h, cfg.meals.breakfast) || within(h, cfg.meals.lunch) || within(h, cfg.meals.dinner)) {
+        const need = 100 - pg.state.needs.nutrition
+        if (need > 30) { doEat(40); return true }
+        if (need > 15) { doEat(25); return true }
+        if (need > 0) { doEat(10); return true }
+    }
+    return false
+}
+
+export function handleNap({ state, pg, cfg, doNap }) {
+    if (pg.state.needs.energy < cfg.thr.energy && state.napCount < cfg.limits.maxNapsPerDay) {
+        doNap(20)
+        return true
+    }
+    return false
+}
+
+export function handleSocial({ state, pg, cfg, doSocial, isWeekend }) {
+    const h = state.time.getHours()
+    if ((isWeekend() || h >= 19) && pg.state.needs.social < cfg.thr.social) {
+        doSocial(90)
+        return true
+    }
+    return false
+}
+
+export function handleFun({ pg, cfg, doFun }) {
+    if (pg.state.needs.fun < cfg.thr.fun) {
+        doFun(60)
+        return true
+    }
+    return false
+}
+
+export function handleHygiene({ pg, cfg, doWash }) {
+    if (pg.state.needs.hygiene < cfg.thr.hygiene) {
+        doWash(12)
+        return true
+    }
+    return false
+}
+
+export function handleIdle({ doIdle }) {
+    doIdle(5)
+    return true
+}

--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -30,7 +30,7 @@
       <section class="panel">
         <h2>Stato & Log</h2>
         <div class="kv"><b>Data</b><span>{{ dateLabel }}</span></div>
-        <div class="kv"><b>Attività corrente</b><span>{{ state.activity.name }}</span></div>
+        <div class="kv"><b>Attività corrente</b><span>{{ state.pg.state.activity.name }}</span></div>
         <div class="kv"><b>Lavoro</b><span>{{ cfg.work.on ? 'ON' : 'OFF' }}</span></div>
         <h3>Log eventi</h3>
         <div class="list small" ref="logEl">
@@ -51,9 +51,9 @@
           <tbody>
             <tr v-for="n in needKeys" :key="n">
               <td>{{ labelsNeed[n] }}</td>
-              <td>{{ Math.round(state.needs[n]) }}</td>
+              <td>{{ Math.round(state.pg.state.needs[n]) }}</td>
               <td>
-                <div class="bar"><i :style="{ width: Math.max(0, Math.min(100, state.needs[n])) + '%' }"></i></div>
+                <div class="bar"><i :style="{ width: Math.max(0, Math.min(100, state.pg.state.needs[n])) + '%' }"></i></div>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
## Summary
- Replace Universe state slices with a PG instance that manages needs and activity
- Move scheduling and per-minute logic into the PG class
- Introduce rule module for sequential activity selection
- Update UI bindings to read needs and activity from PG

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a748c77a1483328233d758d9dede82