### PR TITLE
Avoid consecutive meals via lastMealTime tracking

### DIFF
--- a/src/sim/pg/PG.js
+++ b/src/sim/pg/PG.js
@@ -7,7 +7,7 @@ export class PG {
         this.state = reactive({
             needs: { energy: 95, nutrition: 85, hygiene: 80, social: 75, fun: 80 },
             activity: { name: 'Idle', until: null },
-            meta: { lastMeal: null, lastSleep: null, lastWash: null },
+            meta: { lastMealTime: null, lastSleep: null, lastWash: null },
         })
         this.time = startTime
     }
@@ -28,5 +28,9 @@ export class PG {
         for (const k of Object.keys(this.state.needs)) {
             this.state.needs[k] = Math.max(0, Math.min(100, this.state.needs[k]))
         }
+    }
+
+    recordMeal() {
+        this.state.meta.lastMealTime = this.time
     }
 }

--- a/src/sim/universe/Universe.js
+++ b/src/sim/universe/Universe.js
@@ -102,8 +102,12 @@ export function createUniverse() {
 
         // Fine attività
         if (state.activity.until && state.time >= state.activity.until) {
-            log(`Fine ${state.activity.name}`)
+            const finished = state.activity.name
+            log(`Fine ${finished}`)
             state.activity = { name: 'Idle', until: null }
+            if (finished === 'Mangiare') {
+                state.meta.lastMealTime = new Date(state.time)
+            }
         }
 
         const h = state.time.getHours()
@@ -134,14 +138,17 @@ export function createUniverse() {
             within(h, cfg.meals.lunch) ||
             within(h, cfg.meals.dinner)) {
 
-            const need = 100 - state.needs.nutrition
+            const lastMeal = state.meta.lastMealTime
+            if (!lastMeal || (state.time - lastMeal) >= 3 * 60 * 60 * 1000) {
+                const need = 100 - state.needs.nutrition
 
-            if (need > 30) {
-                return doEat(40) //pasto completo
-            } else if (need > 15) {
-                return doEat(25) //pasto normale
-            } else if (need > 0) {
-                return doEat(10) //spuntino
+                if (need > 30) {
+                    return doEat(40) //pasto completo
+                } else if (need > 15) {
+                    return doEat(25) //pasto normale
+                } else if (need > 0) {
+                    return doEat(10) //spuntino
+                }
             }
 
         }


### PR DESCRIPTION
## Summary
- record lastMealTime when meals finish and skip meal checks if the last meal was <3h ago
- extend PG class with recordMeal helper and meta.lastMealTime state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a748d8b5a88332962386e1df4d5595