### PR TITLE
Track activity duration with notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "vue": "^3.4.21"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/sim/pg/PG.js
+++ b/src/sim/pg/PG.js
@@ -7,7 +7,7 @@ export class PG {
         this.log = logFn
         this.state = reactive({
             needs: { energy: 95, nutrition: 85, hygiene: 80, social: 75, fun: 80 },
-            activity: { name: 'Idle', until: null },
+            activity: { name: 'Idle', until: null, start: null },
             meta: {
                 lastMealTime: null,
                 lastSleepTime: null,
@@ -18,9 +18,10 @@ export class PG {
     }
 
     schedule(currentTime, name, minutes) {
+        const start = new Date(currentTime)
         const until = new Date(currentTime.getTime() + minutes * 60000)
-        this.state.activity = { name, until }
-        if (this.log) this.log(`Inizio ${name} (${minutes}m)`)
+        this.state.activity = { name, until, start }
+        if (this.log) this.log(`Iniziato ${name}`)
         return until
     }
 

--- a/src/sim/universe/Universe.js
+++ b/src/sim/universe/Universe.js
@@ -4,7 +4,14 @@ import { defaultConfig } from '../config/defaultConfig'
 import { createPG } from '../pg/PG.js'
 import { handleSleep, handleWork, handleEmergencies, handleMeals, handleNap, handleSocial, handleFun, handleHygiene, handleIdle } from './rules'
 
-
+function formatDuration(ms) {
+    const totalMinutes = Math.round(ms / 60000)
+    const hours = Math.floor(totalMinutes / 60)
+    const minutes = totalMinutes % 60
+    if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`
+    if (hours > 0) return `${hours}h`
+    return `${minutes}m`
+}
 export function createUniverse() {
     const cfg = reactive(defaultConfig())
     const state = reactive({
@@ -91,8 +98,10 @@ export function createUniverse() {
                 const m = mealTypeAt(state.time)
                 state.pg.recordMeal(state.time, m)
             }
-            log(`Fine ${state.pg.state.activity.name}`)
-            state.pg.state.activity = { name: 'Idle', until: null }
+            const activity = state.pg.state.activity
+            const dur = state.time - activity.start
+            log(`Finito ${activity.name} (durata ${formatDuration(dur)})`)
+            state.pg.state.activity = { name: 'Idle', until: null, start: null }
         }
 
         if (state.time.getHours() === cfg.time.startHour && state.time.getMinutes() === 0) {

--- a/tests/activity.test.js
+++ b/tests/activity.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { createUniverse } from '../src/sim/universe/Universe.js'
+
+describe('activity notifications', () => {
+  it('sends single start and end notification for repeated activity', () => {
+    const { state, logs, step } = createUniverse()
+
+    state.pg.schedule(state.time, 'Test', 1)
+    expect(logs.filter(l => l.includes('Iniziato Test')).length).toBe(1)
+
+    step()
+    step()
+
+    expect(logs.filter(l => l.includes('Iniziato Test')).length).toBe(1)
+    expect(logs.filter(l => l.includes('Finito Test')).length).toBe(1)
+
+    state.pg.schedule(state.time, 'Test', 1)
+    step()
+    step()
+
+    expect(logs.filter(l => l.includes('Iniziato Test')).length).toBe(2)
+    expect(logs.filter(l => l.includes('Finito Test')).length).toBe(2)
+  })
+
+  it('calculates and formats duration correctly', () => {
+    const { state, logs, step } = createUniverse()
+    state.pg.schedule(state.time, 'Test', 65)
+
+    for (let i = 0; i < 65; i++) {
+      step()
+    }
+    step()
+
+    const endLogs = logs.filter(l => l.includes('Finito Test'))
+    const last = endLogs[endLogs.length - 1]
+    expect(last).toMatch(/1h 5m\)$/)
+  })
+})


### PR DESCRIPTION
## Summary
- track start time for each scheduled activity and log start messages
- log activity completion with formatted duration
- add vitest tests for notification count and duration formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a75ed2b7cc8332a7d630f0cc2db9a6