### PR TITLE
Handle repeated activities without restart

### DIFF
--- a/src/sim/pg/PG.js
+++ b/src/sim/pg/PG.js
@@ -1,5 +1,14 @@
 import { reactive } from 'vue'
 
+function formatDuration(ms) {
+    const totalMinutes = Math.round(ms / 60000)
+    const hours = Math.floor(totalMinutes / 60)
+    const minutes = totalMinutes % 60
+    if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`
+    if (hours > 0) return `${hours}h`
+    return `${minutes}m`
+}
+
 export class PG {
     constructor(name, cfg, logFn) {
         this.name = name
@@ -18,6 +27,18 @@ export class PG {
     }
 
     schedule(currentTime, name, minutes) {
+        const activity = this.state.activity
+
+        if (activity.name === name && activity.until && currentTime >= activity.until) {
+            activity.until = new Date(activity.until.getTime() + minutes * 60000)
+            return activity.until
+        }
+
+        if (activity.start) {
+            const dur = currentTime - activity.start
+            if (this.log) this.log(`Finito ${activity.name} (durata ${formatDuration(dur)})`)
+        }
+
         const start = new Date(currentTime)
         const until = new Date(currentTime.getTime() + minutes * 60000)
         this.state.activity = { name, until, start }

--- a/src/sim/universe/Universe.js
+++ b/src/sim/universe/Universe.js
@@ -3,15 +3,6 @@ import { reactive } from 'vue'
 import { defaultConfig } from '../config/defaultConfig'
 import { createPG } from '../pg/PG.js'
 import { handleSleep, handleWork, handleEmergencies, handleMeals, handleNap, handleSocial, handleFun, handleHygiene, handleIdle } from './rules'
-
-function formatDuration(ms) {
-    const totalMinutes = Math.round(ms / 60000)
-    const hours = Math.floor(totalMinutes / 60)
-    const minutes = totalMinutes % 60
-    if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`
-    if (hours > 0) return `${hours}h`
-    return `${minutes}m`
-}
 export function createUniverse() {
     const cfg = reactive(defaultConfig())
     const state = reactive({
@@ -93,15 +84,9 @@ export function createUniverse() {
             return
         }
 
-        if (state.pg.state.activity.until && state.time >= state.pg.state.activity.until) {
-            if (state.pg.state.activity.name === 'Mangiare') {
-                const m = mealTypeAt(state.time)
-                state.pg.recordMeal(state.time, m)
-            }
-            const activity = state.pg.state.activity
-            const dur = state.time - activity.start
-            log(`Finito ${activity.name} (durata ${formatDuration(dur)})`)
-            state.pg.state.activity = { name: 'Idle', until: null, start: null }
+        if (state.pg.state.activity.until && state.time >= state.pg.state.activity.until && state.pg.state.activity.name === 'Mangiare') {
+            const m = mealTypeAt(state.time)
+            state.pg.recordMeal(state.time, m)
         }
 
         if (state.time.getHours() === cfg.time.startHour && state.time.getMinutes() === 0) {

--- a/tests/activity.test.js
+++ b/tests/activity.test.js
@@ -22,6 +22,24 @@ describe('activity notifications', () => {
     expect(logs.filter(l => l.includes('Finito Test')).length).toBe(2)
   })
 
+  it('logs once for continuous repeated work activity', () => {
+    const { state, logs, step } = createUniverse()
+    state.time = new Date(2025, 0, 1, 9, 0, 0, 0)
+    state.pg.schedule(state.time, 'Lavorare', 30)
+
+    for (let i = 0; i < 5; i++) {
+      for (let j = 0; j < 30; j++) step()
+      state.pg.schedule(state.time, 'Lavorare', 30)
+    }
+    for (let j = 0; j < 30; j++) step()
+    state.pg.schedule(state.time, 'Svago', 30)
+
+    const startLogs = logs.filter(l => l.includes('Iniziato Lavorare'))
+    const endLogs = logs.filter(l => l.includes('Finito Lavorare'))
+    expect(startLogs.length).toBe(1)
+    expect(endLogs.length).toBe(1)
+  })
+
   it('calculates and formats duration correctly', () => {
     const { state, logs, step } = createUniverse()
     state.pg.schedule(state.time, 'Test', 65)


### PR DESCRIPTION
## Summary
- Extend ongoing activity instead of restarting when the same action is rescheduled
- Move activity completion logging into `PG.schedule` and simplify `Universe.advanceMinute`
- Add regression test ensuring repeated work logs only once

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7625004348332ba98a3c18d11ff43