### PR TITLE
Add critical needs thresholds and shared checkPrimaryNeeds

### DIFF
--- a/src/sim/config/defaultConfig.js
+++ b/src/sim/config/defaultConfig.js
@@ -12,6 +12,7 @@ export function defaultConfig() {
             social: 1.5,
             fun: 2.0
         },
-        thr: { energy: 35, nutrition: 30, hygiene: 25, social: 35, fun: 35 }
+        thr: { energy: 35, nutrition: 30, hygiene: 25, social: 35, fun: 35 },
+        crit: { energy: 20, nutrition: 15, hygiene: 15 }
     }
 }

--- a/src/sim/pg/PG.js
+++ b/src/sim/pg/PG.js
@@ -105,7 +105,16 @@ export class PG {
             this.state.meta.meals[type] = !this.state.meta.meals[type]
         }
     }
-}
+
+    checkPrimaryNeeds({ doNap, doEat, doWash }) {
+        const needs = this.state.needs
+        const crit = this.cfg.crit
+        if (needs.energy < crit.energy) { doNap(30); return true }
+        if (needs.nutrition < crit.nutrition) { doEat(45); return true }
+        if (needs.hygiene < crit.hygiene) { doWash(12); return true }
+        return false
+    }
+  }
 
 export function createPG(cfg, log) {
     return new PG('PG', cfg, log)

--- a/src/sim/universe/rules.js
+++ b/src/sim/universe/rules.js
@@ -11,9 +11,7 @@ export function handleWork({ state, pg, cfg, doNap, doEat, doWash, doWork, isWee
     const h = state.time.getHours()
     const workOn = cfg.work.on && !isWeekend()
     if (workOn && h >= cfg.work.start && h < cfg.work.end) {
-        if (pg.state.needs.energy < 20) { doNap(30); return true }
-        if (pg.state.needs.nutrition < 15) { doEat(45); return true }
-        if (pg.state.needs.hygiene < 15) { doWash(12); return true }
+        if (pg.checkPrimaryNeeds({ doNap, doEat, doWash })) return true
         doWork(30)
         return true
     }
@@ -21,9 +19,7 @@ export function handleWork({ state, pg, cfg, doNap, doEat, doWash, doWork, isWee
 }
 
 export function handleEmergencies({ pg, doNap, doEat, doWash }) {
-    if (pg.state.needs.energy < 20) { doNap(30); return true }
-    if (pg.state.needs.nutrition < 15) { doEat(45); return true }
-    if (pg.state.needs.hygiene < 15) { doWash(12); return true }
+    if (pg.checkPrimaryNeeds({ doNap, doEat, doWash })) return true
     return false
 }
 

--- a/tests/needs.test.js
+++ b/tests/needs.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PG } from '../src/sim/pg/PG.js'
+import { defaultConfig } from '../src/sim/config/defaultConfig.js'
+
+describe('checkPrimaryNeeds', () => {
+    let pg
+    const cfg = defaultConfig()
+
+    beforeEach(() => {
+        pg = new PG('PG', cfg, () => {})
+    })
+
+    it('triggers nap when energy below critical', () => {
+        pg.state.needs.energy = cfg.crit.energy - 1
+        const doNap = vi.fn()
+        const triggered = pg.checkPrimaryNeeds({ doNap, doEat: vi.fn(), doWash: vi.fn() })
+        expect(triggered).toBe(true)
+        expect(doNap).toHaveBeenCalledWith(30)
+    })
+
+    it('triggers meal when nutrition below critical', () => {
+        pg.state.needs.nutrition = cfg.crit.nutrition - 1
+        const doEat = vi.fn()
+        const triggered = pg.checkPrimaryNeeds({ doNap: vi.fn(), doEat, doWash: vi.fn() })
+        expect(triggered).toBe(true)
+        expect(doEat).toHaveBeenCalledWith(45)
+    })
+
+    it('triggers wash when hygiene below critical', () => {
+        pg.state.needs.hygiene = cfg.crit.hygiene - 1
+        const doWash = vi.fn()
+        const triggered = pg.checkPrimaryNeeds({ doNap: vi.fn(), doEat: vi.fn(), doWash })
+        expect(triggered).toBe(true)
+        expect(doWash).toHaveBeenCalledWith(12)
+    })
+
+    it('returns false when all needs satisfied', () => {
+        const actions = { doNap: vi.fn(), doEat: vi.fn(), doWash: vi.fn() }
+        const triggered = pg.checkPrimaryNeeds(actions)
+        expect(triggered).toBe(false)
+        expect(actions.doNap).not.toHaveBeenCalled()
+        expect(actions.doEat).not.toHaveBeenCalled()
+        expect(actions.doWash).not.toHaveBeenCalled()
+    })
+})
+


### PR DESCRIPTION
## Summary
- allow configuring critical need thresholds via new `crit` config
- introduce `PG.checkPrimaryNeeds` to handle emergency naps, meals, and showers
- refactor work and emergency handlers to use centralized primary need check
- add unit tests for primary need triggers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a77c5c45508332b19d63c8606e1eba