### PR TITLE
Refactor sleep handling into variants

### DIFF
--- a/src/sim/activities/ActivityRegistry.js
+++ b/src/sim/activities/ActivityRegistry.js
@@ -1,0 +1,5 @@
+import { SleepActivity } from './SleepActivity.js'
+
+export const ActivityRegistry = {
+    sleep: SleepActivity,
+}

--- a/src/sim/activities/SleepActivity.js
+++ b/src/sim/activities/SleepActivity.js
@@ -1,0 +1,22 @@
+export const SleepActivity = {
+    variants: {
+        night: {
+            label: 'Dormire',
+            duration: 480,
+            energyPerMinute: 12.5 / 60,
+            nutritionPerMinute: -1.0 / 60,
+        },
+        short: {
+            label: 'Dormire (short)',
+            duration: 120,
+            energyPerMinute: 8 / 60,
+            nutritionPerMinute: -0.5 / 60,
+        },
+        power: {
+            label: 'Dormire (power)',
+            duration: 20,
+            energyPerMinute: 0.5,
+            nutritionPerMinute: 0,
+        },
+    },
+}

--- a/src/sim/pg/PG.js
+++ b/src/sim/pg/PG.js
@@ -1,4 +1,5 @@
 import { reactive } from 'vue'
+import { SleepActivity } from '../activities/SleepActivity.js'
 
 function formatDuration(ms) {
     const totalMinutes = Math.round(ms / 60000)
@@ -65,12 +66,17 @@ export class PG {
     applyActivityMinute(currentTime) {
         const a = this.state.activity.name
         switch (a) {
-            case 'Dormire':
-                this.state.needs.energy = Math.min(100, this.state.needs.energy + (12.5 / 60))
-                this.state.needs.nutrition -= (1.0 / 60)
+            case SleepActivity.variants.night.label:
+                this.state.needs.energy = Math.min(100, this.state.needs.energy + SleepActivity.variants.night.energyPerMinute)
+                this.state.needs.nutrition -= (-SleepActivity.variants.night.nutritionPerMinute)
                 break
-            case 'Power-nap':
-                this.state.needs.energy = Math.min(100, this.state.needs.energy + 0.5)
+            case SleepActivity.variants.short.label:
+                this.state.needs.energy = Math.min(100, this.state.needs.energy + SleepActivity.variants.short.energyPerMinute)
+                this.state.needs.nutrition -= (-SleepActivity.variants.short.nutritionPerMinute)
+                break
+            case SleepActivity.variants.power.label:
+                this.state.needs.energy = Math.min(100, this.state.needs.energy + SleepActivity.variants.power.energyPerMinute)
+                this.state.needs.nutrition -= (-SleepActivity.variants.power.nutritionPerMinute)
                 break
             case 'Mangiare':
                 this.state.needs.nutrition = Math.min(100, this.state.needs.nutrition + (50 / 40))
@@ -94,8 +100,8 @@ export class PG {
                 this.state.needs.energy = Math.min(100, this.state.needs.energy + 0.2)
                 break
         }
-        if (a !== 'Dormire') this.decayMinute()
-        else this.clampNeeds()
+        if (a === SleepActivity.variants.night.label) this.clampNeeds()
+        else this.decayMinute()
         return new Date(currentTime.getTime() + 60000)
     }
 
@@ -106,10 +112,10 @@ export class PG {
         }
     }
 
-    checkPrimaryNeeds({ doNap, doEat, doWash }) {
+    checkPrimaryNeeds({ doSleep, doEat, doWash }) {
         const needs = this.state.needs
         const crit = this.cfg.crit
-        if (needs.energy < crit.energy) { doNap(30); return true }
+        if (needs.energy < crit.energy) { doSleep('power', 30); return true }
         if (needs.nutrition < crit.nutrition) { doEat(45); return true }
         if (needs.hygiene < crit.hygiene) { doWash(12); return true }
         return false

--- a/src/sim/universe/Universe.js
+++ b/src/sim/universe/Universe.js
@@ -2,6 +2,7 @@
 import { reactive } from 'vue'
 import { defaultConfig } from '../config/defaultConfig'
 import { createPG } from '../pg/PG.js'
+import { SleepActivity } from '../activities/SleepActivity.js'
 import { handleSleep, handleWork, handleEmergencies, handleMeals, handleNap, handleSocial, handleFun, handleHygiene, handleIdle } from './rules'
 export function createUniverse() {
     const cfg = reactive(defaultConfig())
@@ -101,7 +102,7 @@ export function createUniverse() {
             within,
             isWeekend,
             doSleepNight,
-            doNap,
+            doSleep,
             doEat,
             doWash,
             doSocial,
@@ -138,9 +139,13 @@ export function createUniverse() {
             targetEnd.setHours(7, 0, 0, 0)
         }
         let minutes = Math.max(360, Math.min(540, (targetEnd - state.time) / 60000))
-        state.pg.schedule(state.time, 'Dormire', minutes)
+        state.pg.schedule(state.time, SleepActivity.variants.night.label, minutes)
     }
-    function doNap(minutes) { state.napCount++; state.pg.schedule(state.time, 'Power-nap', minutes) }
+    function doSleep(variant, minutes) {
+        if (variant === 'power') state.napCount++
+        const label = SleepActivity.variants[variant]?.label || SleepActivity.variants.night.label
+        state.pg.schedule(state.time, label, minutes)
+    }
     function doEat(minutes) { state.pg.schedule(state.time, 'Mangiare', minutes) }
     function doWash(minutes) { state.pg.schedule(state.time, 'Lavarsi', minutes) }
     function doSocial(minutes) { state.pg.schedule(state.time, 'Socializzare', minutes) }

--- a/src/sim/universe/rules.js
+++ b/src/sim/universe/rules.js
@@ -7,19 +7,19 @@ export function handleSleep({ state, pg, doSleepNight }) {
     return false
 }
 
-export function handleWork({ state, pg, cfg, doNap, doEat, doWash, doWork, isWeekend }) {
+export function handleWork({ state, pg, cfg, doSleep, doEat, doWash, doWork, isWeekend }) {
     const h = state.time.getHours()
     const workOn = cfg.work.on && !isWeekend()
     if (workOn && h >= cfg.work.start && h < cfg.work.end) {
-        if (pg.checkPrimaryNeeds({ doNap, doEat, doWash })) return true
+        if (pg.checkPrimaryNeeds({ doSleep, doEat, doWash })) return true
         doWork(30)
         return true
     }
     return false
 }
 
-export function handleEmergencies({ pg, doNap, doEat, doWash }) {
-    if (pg.checkPrimaryNeeds({ doNap, doEat, doWash })) return true
+export function handleEmergencies({ pg, doSleep, doEat, doWash }) {
+    if (pg.checkPrimaryNeeds({ doSleep, doEat, doWash })) return true
     return false
 }
 
@@ -37,9 +37,9 @@ export function handleMeals({ state, pg, cfg, doEat, within }) {
     return false
 }
 
-export function handleNap({ state, pg, cfg, doNap }) {
+export function handleNap({ state, pg, cfg, doSleep }) {
     if (pg.state.needs.energy < cfg.thr.energy && state.napCount < cfg.limits.maxNapsPerDay) {
-        doNap(20)
+        doSleep('power', 20)
         return true
     }
     return false

--- a/tests/needs.test.js
+++ b/tests/needs.test.js
@@ -10,18 +10,18 @@ describe('checkPrimaryNeeds', () => {
         pg = new PG('PG', cfg, () => {})
     })
 
-    it('triggers nap when energy below critical', () => {
+    it('triggers power sleep when energy below critical', () => {
         pg.state.needs.energy = cfg.crit.energy - 1
-        const doNap = vi.fn()
-        const triggered = pg.checkPrimaryNeeds({ doNap, doEat: vi.fn(), doWash: vi.fn() })
+        const doSleep = vi.fn()
+        const triggered = pg.checkPrimaryNeeds({ doSleep, doEat: vi.fn(), doWash: vi.fn() })
         expect(triggered).toBe(true)
-        expect(doNap).toHaveBeenCalledWith(30)
+        expect(doSleep).toHaveBeenCalledWith('power', 30)
     })
 
     it('triggers meal when nutrition below critical', () => {
         pg.state.needs.nutrition = cfg.crit.nutrition - 1
         const doEat = vi.fn()
-        const triggered = pg.checkPrimaryNeeds({ doNap: vi.fn(), doEat, doWash: vi.fn() })
+        const triggered = pg.checkPrimaryNeeds({ doSleep: vi.fn(), doEat, doWash: vi.fn() })
         expect(triggered).toBe(true)
         expect(doEat).toHaveBeenCalledWith(45)
     })
@@ -29,16 +29,16 @@ describe('checkPrimaryNeeds', () => {
     it('triggers wash when hygiene below critical', () => {
         pg.state.needs.hygiene = cfg.crit.hygiene - 1
         const doWash = vi.fn()
-        const triggered = pg.checkPrimaryNeeds({ doNap: vi.fn(), doEat: vi.fn(), doWash })
+        const triggered = pg.checkPrimaryNeeds({ doSleep: vi.fn(), doEat: vi.fn(), doWash })
         expect(triggered).toBe(true)
         expect(doWash).toHaveBeenCalledWith(12)
     })
 
     it('returns false when all needs satisfied', () => {
-        const actions = { doNap: vi.fn(), doEat: vi.fn(), doWash: vi.fn() }
+        const actions = { doSleep: vi.fn(), doEat: vi.fn(), doWash: vi.fn() }
         const triggered = pg.checkPrimaryNeeds(actions)
         expect(triggered).toBe(false)
-        expect(actions.doNap).not.toHaveBeenCalled()
+        expect(actions.doSleep).not.toHaveBeenCalled()
         expect(actions.doEat).not.toHaveBeenCalled()
         expect(actions.doWash).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
## Summary
- add `sleep` activity variants short and power and register them
- replace nap with power sleep variant across simulation logic
- update primary needs tests for new sleep interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78162e5f083328a5c42515a8c3418