### PR TITLE
Add configurable work activity with block scheduling

### DIFF
--- a/src/sim/activities/ActivityRegistry.js
+++ b/src/sim/activities/ActivityRegistry.js
@@ -1,5 +1,7 @@
 import { SleepActivity } from './SleepActivity.js'
+import { WorkActivity } from './WorkActivity.js'
 
 export const ActivityRegistry = {
     sleep: SleepActivity,
+    work: WorkActivity,
 }

--- a/src/sim/activities/WorkActivity.js
+++ b/src/sim/activities/WorkActivity.js
@@ -1,0 +1,59 @@
+export const WorkActivity = {
+    variants: {
+        block: {
+            label: 'Lavorare',
+            duration: 30,
+            energyPerMinute: -4.0 / 60,
+            nutritionPerMinute: -2.0 / 60,
+        },
+    },
+    /**
+     * Crea un orario di lavoro composto da blocchi di durata fissa
+     * permettendo di inserire altre attività all'interno.
+     * @param {Date} start - ora di inizio lavoro
+     * @param {Date} end - ora di fine lavoro
+     * @param {number} [blockMinutes=WorkActivity.variants.block.duration] - durata del blocco base
+     * @param {Array<{start: Date, name: string, duration: number}>} [inserts=[]]
+     *        attività da inserire all'interno dell'orario
+     * @returns {Array<{start: Date, name: string, duration: number}>} - lista ordinata di attività
+     */
+    buildSchedule(start, end, blockMinutes = 30, inserts = []) {
+        const result = []
+        const extras = [...inserts].sort((a, b) => a.start - b.start)
+        const blockLabel = WorkActivity.variants.block.label
+        let current = new Date(start)
+        let i = 0
+        while (current < end) {
+            const nextExtra = extras[i]
+            if (nextExtra && current >= nextExtra.start && current < new Date(nextExtra.start.getTime() + nextExtra.duration * 60000)) {
+                // If current overlaps an extra, skip to end of extra
+                current = new Date(nextExtra.start.getTime() + nextExtra.duration * 60000)
+                i++
+                continue
+            }
+            if (nextExtra && nextExtra.start <= end && nextExtra.start > current) {
+                // Fill work blocks until next extra starts
+                const minutesUntilExtra = (nextExtra.start - current) / 60000
+                let remaining = minutesUntilExtra
+                while (remaining > 0) {
+                    const chunk = Math.min(blockMinutes, remaining)
+                    result.push({ start: new Date(current), name: blockLabel, duration: chunk })
+                    current = new Date(current.getTime() + chunk * 60000)
+                    remaining -= chunk
+                }
+                // add the extra
+                result.push({ start: new Date(nextExtra.start), name: nextExtra.name, duration: nextExtra.duration })
+                current = new Date(nextExtra.start.getTime() + nextExtra.duration * 60000)
+                i++
+            } else {
+                // No more extras or extras after end; fill work blocks until end
+                const minutesLeft = (end - current) / 60000
+                if (minutesLeft <= 0) break
+                const chunk = Math.min(blockMinutes, minutesLeft)
+                result.push({ start: new Date(current), name: blockLabel, duration: chunk })
+                current = new Date(current.getTime() + chunk * 60000)
+            }
+        }
+        return result
+    },
+}

--- a/tests/activity.test.js
+++ b/tests/activity.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { createUniverse } from '../src/sim/universe/Universe.js'
+import { WorkActivity } from '../src/sim/activities/WorkActivity.js'
 
 describe('activity notifications', () => {
   it('sends single start and end notification for repeated activity', () => {
@@ -25,19 +26,45 @@ describe('activity notifications', () => {
   it('logs once for continuous repeated work activity', () => {
     const { state, logs, step } = createUniverse()
     state.time = new Date(2025, 0, 1, 9, 0, 0, 0)
-    state.pg.schedule(state.time, 'Lavorare', 30)
-
-    for (let i = 0; i < 5; i++) {
-      for (let j = 0; j < 30; j++) step()
-      state.pg.schedule(state.time, 'Lavorare', 30)
+    const schedule = WorkActivity.buildSchedule(state.time, new Date(2025, 0, 1, 12, 0, 0, 0))
+    for (const ev of schedule) {
+      state.pg.schedule(state.time, ev.name, ev.duration)
+      for (let i = 0; i < ev.duration; i++) step()
     }
-    for (let j = 0; j < 30; j++) step()
     state.pg.schedule(state.time, 'Svago', 30)
+    for (let j = 0; j < 30; j++) step()
 
     const startLogs = logs.filter(l => l.includes('Iniziato Lavorare'))
     const endLogs = logs.filter(l => l.includes('Finito Lavorare'))
     expect(startLogs.length).toBe(1)
     expect(endLogs.length).toBe(1)
+  })
+
+  it('allows inserting other activities within work schedule', () => {
+    const { state, logs, step } = createUniverse()
+    state.time = new Date(2025, 0, 1, 9, 0, 0, 0)
+    const schedule = WorkActivity.buildSchedule(
+      state.time,
+      new Date(2025, 0, 1, 13, 0, 0, 0),
+      30,
+      [
+        { start: new Date(2025, 0, 1, 11, 0, 0, 0), name: 'Mangiare', duration: 30 },
+        { start: new Date(2025, 0, 1, 12, 0, 0, 0), name: 'Pausa bagno', duration: 5 },
+      ]
+    )
+    for (const ev of schedule) {
+      state.pg.schedule(state.time, ev.name, ev.duration)
+      for (let i = 0; i < ev.duration; i++) step()
+    }
+    state.pg.schedule(state.time, 'Svago', 30)
+    for (let j = 0; j < 30; j++) step()
+
+    const startLogs = logs.filter(l => l.includes('Iniziato Lavorare'))
+    const endLogs = logs.filter(l => l.includes('Finito Lavorare'))
+    expect(startLogs.length).toBe(3)
+    expect(endLogs.length).toBe(3)
+    expect(logs.some(l => l.includes('Iniziato Mangiare'))).toBe(true)
+    expect(logs.some(l => l.includes('Iniziato Pausa bagno'))).toBe(true)
   })
 
   it('calculates and formats duration correctly', () => {


### PR DESCRIPTION
## Summary
- introduce `WorkActivity` with 30-minute base block and helper to build schedules with optional inserts
- register work activity in `ActivityRegistry`
- extend activity tests to cover block scheduling and insertion of lunch/break activities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78442bf108332aa1960a79ca95128