### PR TITLE
Refactor activity effects and apply generically

### DIFF
--- a/src/sim/activities/ActivityRegistry.js
+++ b/src/sim/activities/ActivityRegistry.js
@@ -1,7 +1,32 @@
 import { SleepActivity } from './SleepActivity.js'
 import { WorkActivity } from './WorkActivity.js'
 
+const activitiesByLabel = {}
+
+function registerVariants(activity) {
+    if (!activity?.variants) return
+    for (const variant of Object.values(activity.variants)) {
+        activitiesByLabel[variant.label] = variant
+    }
+}
+
+registerVariants(SleepActivity)
+registerVariants(WorkActivity)
+
+const basicActivities = [
+    { label: 'Mangiare', effects: { nutrition: 50 / 40 } },
+    { label: 'Lavarsi', effects: { hygiene: 40 / 12 } },
+    { label: 'Socializzare', effects: { social: 35 / 90, fun: 10 / 90, energy: -1.0 / 60 } },
+    { label: 'Svago', effects: { fun: 25 / 60 } },
+    { label: 'Idle', effects: { energy: 0.2 } },
+]
+
+for (const act of basicActivities) {
+    activitiesByLabel[act.label] = act
+}
+
 export const ActivityRegistry = {
-    sleep: SleepActivity,
-    work: WorkActivity,
+    get(name) {
+        return activitiesByLabel[name]
+    },
 }

--- a/src/sim/activities/SleepActivity.js
+++ b/src/sim/activities/SleepActivity.js
@@ -3,20 +3,27 @@ export const SleepActivity = {
         night: {
             label: 'Dormire',
             duration: 480,
-            energyPerMinute: 12.5 / 60,
-            nutritionPerMinute: -1.0 / 60,
+            effects: {
+                energy: 12.5 / 60,
+                nutrition: -1.0 / 60,
+            },
+            skipDecay: true,
         },
         short: {
             label: 'Dormire (short)',
             duration: 120,
-            energyPerMinute: 8 / 60,
-            nutritionPerMinute: -0.5 / 60,
+            effects: {
+                energy: 8 / 60,
+                nutrition: -0.5 / 60,
+            },
         },
         power: {
             label: 'Dormire (power)',
             duration: 20,
-            energyPerMinute: 0.5,
-            nutritionPerMinute: 0,
+            effects: {
+                energy: 0.5,
+                nutrition: 0,
+            },
         },
     },
 }

--- a/src/sim/activities/WorkActivity.js
+++ b/src/sim/activities/WorkActivity.js
@@ -3,8 +3,10 @@ export const WorkActivity = {
         block: {
             label: 'Lavorare',
             duration: 30,
-            energyPerMinute: -4.0 / 60,
-            nutritionPerMinute: -2.0 / 60,
+            effects: {
+                energy: -4.0 / 60,
+                nutrition: -2.0 / 60,
+            },
         },
     },
     /**


### PR DESCRIPTION
## Summary
- Replace PG activity switch with registry lookup and generic effect application
- Add per-minute effects to activity definitions and register common activities
- Introduce helper to apply decay or clamping based on activity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78ff7772883328fa1ad9660756917