### PR TITLE
Refactor activity scheduling to use registry keys

### DIFF
--- a/src/sim/activities/ActivityRegistry.js
+++ b/src/sim/activities/ActivityRegistry.js
@@ -1,32 +1,48 @@
 import { SleepActivity } from './SleepActivity.js'
 import { WorkActivity } from './WorkActivity.js'
 
+// Store activities by both internal key and user-visible label
+const activitiesByKey = {}
 const activitiesByLabel = {}
 
-function registerVariants(activity) {
+/**
+ * Register activity variants using an optional prefix to avoid key collisions.
+ * Variants can then be retrieved either by their internal key (e.g. `work.block`)
+ * or by their label (e.g. `Lavorare`).
+ */
+function registerVariants(activity, prefix = '') {
     if (!activity?.variants) return
-    for (const variant of Object.values(activity.variants)) {
+    for (const [key, variant] of Object.entries(activity.variants)) {
+        const k = prefix ? `${prefix}.${key}` : key
+        activitiesByKey[k] = variant
         activitiesByLabel[variant.label] = variant
     }
 }
 
-registerVariants(SleepActivity)
-registerVariants(WorkActivity)
+// Register complex activities with a namespace prefix
+registerVariants(SleepActivity, 'sleep')
+registerVariants(WorkActivity, 'work')
 
-const basicActivities = [
-    { label: 'Mangiare', effects: { nutrition: 50 / 40 } },
-    { label: 'Lavarsi', effects: { hygiene: 40 / 12 } },
-    { label: 'Socializzare', effects: { social: 35 / 90, fun: 10 / 90, energy: -1.0 / 60 } },
-    { label: 'Svago', effects: { fun: 25 / 60 } },
-    { label: 'Idle', effects: { energy: 0.2 } },
-]
+// Basic activities are keyed explicitly
+const basicActivities = {
+    eat: { label: 'Mangiare', effects: { nutrition: 50 / 40 } },
+    wash: { label: 'Lavarsi', effects: { hygiene: 40 / 12 } },
+    social: { label: 'Socializzare', effects: { social: 35 / 90, fun: 10 / 90, energy: -1.0 / 60 } },
+    fun: { label: 'Svago', effects: { fun: 25 / 60 } },
+    idle: { label: 'Idle', effects: { energy: 0.2 } },
+}
 
-for (const act of basicActivities) {
+for (const [key, act] of Object.entries(basicActivities)) {
+    activitiesByKey[key] = act
     activitiesByLabel[act.label] = act
 }
 
 export const ActivityRegistry = {
-    get(name) {
-        return activitiesByLabel[name]
+    /**
+     * Retrieve an activity by internal key or label.
+     * @param {string} key
+     */
+    get(key) {
+        return activitiesByKey[key] || activitiesByLabel[key]
     },
 }

--- a/src/sim/universe/Universe.js
+++ b/src/sim/universe/Universe.js
@@ -3,6 +3,7 @@ import { reactive } from 'vue'
 import { defaultConfig } from '../config/defaultConfig'
 import { createPG } from '../pg/PG.js'
 import { SleepActivity } from '../activities/SleepActivity.js'
+import { ActivityRegistry } from '../activities/ActivityRegistry.js'
 import { handleSleep, handleWork, handleEmergencies, handleMeals, handleNap, handleSocial, handleFun, handleHygiene, handleIdle } from './rules'
 export function createUniverse() {
     const cfg = reactive(defaultConfig())
@@ -146,12 +147,18 @@ export function createUniverse() {
         const label = SleepActivity.variants[variant]?.label || SleepActivity.variants.night.label
         state.pg.schedule(state.time, label, minutes)
     }
-    function doEat(minutes) { state.pg.schedule(state.time, 'Mangiare', minutes) }
-    function doWash(minutes) { state.pg.schedule(state.time, 'Lavarsi', minutes) }
-    function doSocial(minutes) { state.pg.schedule(state.time, 'Socializzare', minutes) }
-    function doFun(minutes) { state.pg.schedule(state.time, 'Svago', minutes) }
-    function doWork(minutes) { state.pg.schedule(state.time, 'Lavorare', minutes) }
-    function doIdle(minutes) { state.pg.schedule(state.time, 'Idle', minutes) }
+
+    function scheduleActivity(key, minutes) {
+        const activity = ActivityRegistry.get(key)
+        if (!activity) return
+        state.pg.schedule(state.time, activity.label, minutes)
+    }
+    function doEat(minutes) { scheduleActivity('eat', minutes) }
+    function doWash(minutes) { scheduleActivity('wash', minutes) }
+    function doSocial(minutes) { scheduleActivity('social', minutes) }
+    function doFun(minutes) { scheduleActivity('fun', minutes) }
+    function doWork(minutes) { scheduleActivity('work.block', minutes) }
+    function doIdle(minutes) { scheduleActivity('idle', minutes) }
 
     return { state, cfg, logs, play, pause, step, reinit, setSpeed }
 }


### PR DESCRIPTION
## Summary
- support retrieving activities by internal key within `ActivityRegistry`
- add `scheduleActivity` helper in `Universe` and replace activity wrappers to use keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7935da3708332975afa1878e7b9da