### PR TITLE
Modularize basic activities with per-minute effects

### DIFF
--- a/src/sim/activities/ActivityRegistry.js
+++ b/src/sim/activities/ActivityRegistry.js
@@ -1,5 +1,10 @@
 import { SleepActivity } from './SleepActivity.js'
 import { WorkActivity } from './WorkActivity.js'
+import { EatActivity } from './EatActivity.js'
+import { WashActivity } from './WashActivity.js'
+import { SocialActivity } from './SocialActivity.js'
+import { FunActivity } from './FunActivity.js'
+import { IdleActivity } from './IdleActivity.js'
 
 // Store activities by both internal key and user-visible label
 const activitiesByKey = {}
@@ -19,23 +24,14 @@ function registerVariants(activity, prefix = '') {
     }
 }
 
-// Register complex activities with a namespace prefix
+// Register activities
 registerVariants(SleepActivity, 'sleep')
 registerVariants(WorkActivity, 'work')
-
-// Basic activities are keyed explicitly
-const basicActivities = {
-    eat: { label: 'Mangiare', effects: { nutrition: 50 / 40 } },
-    wash: { label: 'Lavarsi', effects: { hygiene: 40 / 12 } },
-    social: { label: 'Socializzare', effects: { social: 35 / 90, fun: 10 / 90, energy: -1.0 / 60 } },
-    fun: { label: 'Svago', effects: { fun: 25 / 60 } },
-    idle: { label: 'Idle', effects: { energy: 0.2 } },
-}
-
-for (const [key, act] of Object.entries(basicActivities)) {
-    activitiesByKey[key] = act
-    activitiesByLabel[act.label] = act
-}
+registerVariants(EatActivity)
+registerVariants(WashActivity)
+registerVariants(SocialActivity)
+registerVariants(FunActivity)
+registerVariants(IdleActivity)
 
 export const ActivityRegistry = {
     /**

--- a/src/sim/activities/EatActivity.js
+++ b/src/sim/activities/EatActivity.js
@@ -1,0 +1,11 @@
+export const EatActivity = {
+    variants: {
+        eat: {
+            label: 'Mangiare',
+            duration: 40,
+            effects: {
+                nutrition: 50 / 40,
+            },
+        },
+    },
+}

--- a/src/sim/activities/FunActivity.js
+++ b/src/sim/activities/FunActivity.js
@@ -1,0 +1,11 @@
+export const FunActivity = {
+    variants: {
+        fun: {
+            label: 'Svago',
+            duration: 60,
+            effects: {
+                fun: 25 / 60,
+            },
+        },
+    },
+}

--- a/src/sim/activities/IdleActivity.js
+++ b/src/sim/activities/IdleActivity.js
@@ -1,0 +1,11 @@
+export const IdleActivity = {
+    variants: {
+        idle: {
+            label: 'Idle',
+            duration: 5,
+            effects: {
+                energy: 0.2,
+            },
+        },
+    },
+}

--- a/src/sim/activities/SocialActivity.js
+++ b/src/sim/activities/SocialActivity.js
@@ -1,0 +1,13 @@
+export const SocialActivity = {
+    variants: {
+        social: {
+            label: 'Socializzare',
+            duration: 90,
+            effects: {
+                social: 35 / 90,
+                fun: 10 / 90,
+                energy: -1.0 / 60,
+            },
+        },
+    },
+}

--- a/src/sim/activities/WashActivity.js
+++ b/src/sim/activities/WashActivity.js
@@ -1,0 +1,11 @@
+export const WashActivity = {
+    variants: {
+        wash: {
+            label: 'Lavarsi',
+            duration: 12,
+            effects: {
+                hygiene: 40 / 12,
+            },
+        },
+    },
+}


### PR DESCRIPTION
## Summary
- add dedicated Eat, Wash, Social, Fun, and Idle activity modules with default durations and per-minute effects
- register the new activity modules in the ActivityRegistry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a79515555c83329a8dd8357fde7ee4