### PR TITLE
Track daily activities and show daily summary

### DIFF
--- a/src/sim/pg/PG.js
+++ b/src/sim/pg/PG.js
@@ -32,6 +32,7 @@ export class PG {
         this.state = reactive({
             needs: { energy: 95, nutrition: 85, hygiene: 80, social: 75, fun: 80 },
             activity: { name: 'Idle', until: null, start: null },
+            dailyActivities: {},
             meta: {
                 lastMealTime: null,
                 lastSleepTime: null,
@@ -54,6 +55,7 @@ export class PG {
 
         // Extend existing activity if it's the same and has already ended
         if (activity.name === name && activity.until && currentTime >= activity.until) {
+            this.state.dailyActivities[name] = (this.state.dailyActivities[name] || 0) + 1
             activity.until = new Date(activity.until.getTime() + minutes * 60000) // minutes → ms
             return activity.until
         }
@@ -61,6 +63,10 @@ export class PG {
         if (activity.start) {
             const dur = currentTime - activity.start
             if (this.log) this.log(`Finito ${activity.name} (durata ${formatDuration(dur)})`)
+            if (!activity.until || currentTime >= activity.until) {
+                const prev = activity.name
+                this.state.dailyActivities[prev] = (this.state.dailyActivities[prev] || 0) + 1
+            }
         }
 
         const start = new Date(currentTime)

--- a/src/sim/universe/Universe.js
+++ b/src/sim/universe/Universe.js
@@ -151,6 +151,7 @@ export function createUniverse() {
             // At day start reset eaten-meal flags
             const meals = state.pg.state.meta.meals
             meals.breakfast = meals.lunch = meals.dinner = false
+            state.pg.state.dailyActivities = {}
         }
 
         const ctx = {

--- a/src/ui/PgStatus.vue
+++ b/src/ui/PgStatus.vue
@@ -11,6 +11,24 @@
   </section>
 
   <section class="panel">
+    <h2>Attività giornaliere</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Attività</th>
+          <th>Conteggio</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(count, name) in state.pg.state.dailyActivities" :key="name">
+          <td>{{ name }}</td>
+          <td>{{ count }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="panel">
     <h2>Bisogni</h2>
     <table>
       <thead>

--- a/tests/dailyActivities.test.js
+++ b/tests/dailyActivities.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { createUniverse } from '../src/sim/universe/Universe.js'
+
+describe('daily activities tracking', () => {
+  it('increments counter when activity completes', () => {
+    const { state, step } = createUniverse()
+    state.pg.schedule(state.time, 'Test', 1)
+    step()
+    step()
+    expect(state.pg.state.dailyActivities.Test).toBe(1)
+  })
+
+  it('resets counters at day start', () => {
+    const { state, step } = createUniverse()
+    state.pg.state.dailyActivities.Test = 3
+    step()
+    expect(state.pg.state.dailyActivities.Test).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Track daily activity counts in PG state and increment on activity completion
- Reset daily activity counts at day start and display them in the status panel
- Add tests covering daily activity tracking and reset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a79ad3e0248332a733894e4d77d059