### PR TITLE
Handle background music with fade in/out and speed control

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <audio id="loop" loop>
-    <source src="/public/loop.wav" type="audio/wav">
+    <source src="/musica.mp3" type="audio/mpeg">
   </audio>
   <title>Little World — Simulatore</title>
 

--- a/src/sim/pg/PG.js
+++ b/src/sim/pg/PG.js
@@ -160,8 +160,8 @@ export class PG {
         const needs = this.state.needs
         const crit = this.cfg.crit
         if (needs.energy < crit.energy) { doSleep('power', 30); return true }
-        if (needs.nutrition < crit.nutrition) { doEat(40); return true }
-        if (needs.hygiene < crit.hygiene) { doWash(30); return true }
+        if (needs.nutrition < crit.nutrition) { doEat(45); return true }
+        if (needs.hygiene < crit.hygiene) { doWash(12); return true }
         return false
     }
 }

--- a/src/sim/universe/Universe.js
+++ b/src/sim/universe/Universe.js
@@ -53,14 +53,27 @@ export function createUniverse() {
 
     // Controls
 
-    //soundtrack
-    const bg = document.getElementById('loop'); //get the audio from html
-    const FADE_MS = 5000; // durata del fade (0,5 s)
+    // soundtrack
+    const bg = typeof document !== 'undefined' ? document.getElementById('loop') : null
+    const FADE_MS = 500 // durata del fade (0.5 s)
+    const SONG_FACTOR = 1
 
     function fadeAudio(el, targetVol, duration, onEnd) {
-        const startVol = el.volume;
-        const delta = targetVol - startVol;
-        const t0 = performance.now();
+        const startVol = el.volume
+        const delta = targetVol - startVol
+        const t0 = performance.now()
+
+        function tick(t) {
+            const progress = Math.min((t - t0) / duration, 1)
+            el.volume = startVol + delta * progress
+            if (progress < 1) {
+                requestAnimationFrame(tick)
+            } else if (onEnd) {
+                onEnd()
+            }
+        }
+
+        requestAnimationFrame(tick)
     }
     /**
      * Start the simulation loop.
@@ -68,8 +81,11 @@ export function createUniverse() {
      */
     function play() {
         state.running = true
-        bg.play()
-        fadeAudio(bg, 1, FADE_MS);
+        if (bg) {
+            bg.volume = 0
+            bg.play()
+            fadeAudio(bg, 1, FADE_MS)
+        }
         startInterval()
 
     }
@@ -78,9 +94,8 @@ export function createUniverse() {
      * @returns {void}
      */
     function pause() {
+        if (bg) fadeAudio(bg, 0, FADE_MS, () => bg.pause())
         state.running = false
-        bg.pause()
-        fadeAudio(bg, 0, FADE_MS, () => bg.pause());
         if (intervalId) clearInterval(intervalId)
 
     }
@@ -99,6 +114,7 @@ export function createUniverse() {
      */
     function setSpeed(newSpeed) {
         state.speed = newSpeed
+        if (bg) bg.playbackRate = newSpeed * SONG_FACTOR
         if (state.running) startInterval()
     }
 

--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -6,11 +6,6 @@
           <img src="../../favicon.ico" style="max-height: 64px; vertical-align: center;">
           Little World — Simulatore
         </h1>
-        <div>
-          <audio id="loop" loop>
-            <source src="/public/musica.mp3" type="audio/mpeg">
-          </audio>
-        </div>
         <div class="small">Giornata v0 (AI bisogni) + DNA/EV (hard cap 230) • Speed e Back Office</div>
       </div>
       <UniverseControls :speed="speed" :clock-label="clockLabel" :play="play" :pause="pause" :step="step"


### PR DESCRIPTION
## Summary
- remove duplicate audio tag and point source to `/musica.mp3`
- fade background music on play and pause, synchronized with simulation speed
- align primary need emergency durations with test expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a911cdfc0083329b29f94bec8f296d