### PR TITLE
feat: add soundtrack-based audio manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "soundtrack.js": "^0.5.5",
     "vue": "^3.4.21"
   },
   "devDependencies": {

--- a/src/audio/AudioManager.js
+++ b/src/audio/AudioManager.js
@@ -1,0 +1,56 @@
+import Soundtrack from 'soundtrack.js'
+
+/**
+ * AudioManager centralizza la gestione dell'audio di background usando soundtrack.js.
+ * Mantiene lo stato del brano corrente e fornisce metodi basilari di controllo.
+ * L'API è pensata per essere estendibile (es. effetti sonori, playlist multiple).
+ */
+export class AudioManager {
+    constructor() {
+        /** @private */
+        this.soundtrack = null
+        /** @private */
+        this.currentTrack = null
+    }
+
+    /**
+     * Carica un brano usando soundtrack.js.
+     * @param {string} src - Percorso del file audio (default: '/musica.mp3').
+     * @returns {void}
+     */
+    load(src = '/musica.mp3') {
+        if (typeof window === 'undefined') return
+        this.soundtrack = new Soundtrack([{ name: 'bg', src }])
+        this.currentTrack = 'bg'
+    }
+
+    /** Avvia la riproduzione del brano corrente. */
+    play() {
+        if (this.soundtrack && this.currentTrack) {
+            this.soundtrack.play(this.currentTrack)
+        }
+    }
+
+    /** Mette in pausa la riproduzione. */
+    pause() {
+        if (this.soundtrack && this.soundtrack.current !== undefined) {
+            const player = this.soundtrack.players[this.soundtrack.current]
+            if (player) player.pause()
+        }
+    }
+
+    /**
+     * Imposta il volume del brano corrente.
+     * @param {number} v - Volume compreso tra 0 e 1.
+     */
+    setVolume(v) {
+        if (this.soundtrack && this.soundtrack.current !== undefined) {
+            const player = this.soundtrack.players[this.soundtrack.current]
+            if (player) player.volume = v
+        }
+    }
+}
+
+/** Istanza predefinita da riutilizzare nella simulazione. */
+const audioManager = new AudioManager()
+export default audioManager

--- a/src/sim/universe/Universe.js
+++ b/src/sim/universe/Universe.js
@@ -2,6 +2,7 @@
 import { reactive } from 'vue'
 import { defaultConfig } from '../config/defaultConfig'
 import { createPG } from '../pg/PG.js'
+import audioManager from '../../audio/AudioManager.js'
 import { SleepActivity } from '../activities/SleepActivity.js'
 import { ActivityRegistry } from '../activities/ActivityRegistry.js'
 import { handleSleep, handleWork, handleEmergencies, handleMeals, handleNap, handleSocial, handleFun, handleHygiene, handleIdle } from './rules'
@@ -35,6 +36,7 @@ export function createUniverse() {
     }
 
     state.pg = createPG(cfg, log)
+    audioManager.load()
 
     /**
      * Reset the universe to its initial daily state.
@@ -53,9 +55,6 @@ export function createUniverse() {
 
     // Controls
 
-    //soundtrack
-    const bg = document.getElementById('loop'); //get the audio from html
-
     /**
      * Start the simulation loop.
      * @returns {void}
@@ -63,7 +62,7 @@ export function createUniverse() {
     function play() {
         state.running = true
         startInterval()
-        bg.play()
+        audioManager.play()
     }
     /**
      * Pause the simulation loop.
@@ -72,7 +71,7 @@ export function createUniverse() {
     function pause() {
         state.running = false
         if (intervalId) clearInterval(intervalId)
-        bg.pause()
+        audioManager.pause()
     }
     /**
      * Advance the simulation by a single minute.


### PR DESCRIPTION
## Summary
- add `AudioManager` wrapper around soundtrack.js with load/play/pause/volume controls
- integrate `AudioManager` into `Universe` to handle background music
- install `soundtrack.js` dependency

## Testing
- `npm test` (fails: expected "spy" to be called with arguments: [ 45 ] and [ 12 ])

------
https://chatgpt.com/codex/tasks/task_e_68aad4528be88332a60822fe83d37fa1