### PR TITLE
feat: centralize background audio control

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,6 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <audio id="loop" loop>
-    <source src="/public/loop.wav" type="audio/wav">
-  </audio>
   <title>Little World — Simulatore</title>
 
   <style>

--- a/src/audio/AudioManager.js
+++ b/src/audio/AudioManager.js
@@ -1,0 +1,29 @@
+export const AudioManager = {
+  audio: null,
+  init(track = '/public/musica.mp3') {
+    if (!this.audio) {
+      this.audio = new Audio(track)
+      this.audio.loop = true
+    }
+  },
+  play() {
+    if (this.audio) this.audio.play()
+  },
+  pause() {
+    if (this.audio) this.audio.pause()
+  },
+  setTrack(url) {
+    if (!this.audio) {
+      this.init(url)
+    } else {
+      this.audio.src = url
+      this.audio.load()
+    }
+  },
+  setVolume(v) {
+    if (this.audio) this.audio.volume = v
+  },
+  setLoop(loop) {
+    if (this.audio) this.audio.loop = loop
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,6 @@
 import { createApp } from 'vue'
 import App from './ui/App.vue'
+import { AudioManager } from './audio/AudioManager.js'
 
+AudioManager.init()
 createApp(App).mount('#app')

--- a/src/sim/universe/Universe.js
+++ b/src/sim/universe/Universe.js
@@ -5,6 +5,7 @@ import { createPG } from '../pg/PG.js'
 import { SleepActivity } from '../activities/SleepActivity.js'
 import { ActivityRegistry } from '../activities/ActivityRegistry.js'
 import { handleSleep, handleWork, handleEmergencies, handleMeals, handleNap, handleSocial, handleFun, handleHygiene, handleIdle } from './rules'
+import { AudioManager } from '../../audio/AudioManager.js'
 
 /**
  * Create the simulation universe holding state and control helpers.
@@ -53,9 +54,6 @@ export function createUniverse() {
 
     // Controls
 
-    //soundtrack
-    const bg = document.getElementById('loop'); //get the audio from html
-
     /**
      * Start the simulation loop.
      * @returns {void}
@@ -63,7 +61,7 @@ export function createUniverse() {
     function play() {
         state.running = true
         startInterval()
-        bg.play()
+        AudioManager.play()
     }
     /**
      * Pause the simulation loop.
@@ -72,7 +70,7 @@ export function createUniverse() {
     function pause() {
         state.running = false
         if (intervalId) clearInterval(intervalId)
-        bg.pause()
+        AudioManager.pause()
     }
     /**
      * Advance the simulation by a single minute.

--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -6,11 +6,6 @@
           <img src="../../favicon.ico" style="max-height: 64px; vertical-align: center;">
           Little World — Simulatore
         </h1>
-        <div>
-          <audio id="loop" loop>
-            <source src="/public/musica.mp3" type="audio/mpeg">
-          </audio>
-        </div>
         <div class="small">Giornata v0 (AI bisogni) + DNA/EV (hard cap 230) • Speed e Back Office</div>
       </div>
       <UniverseControls :speed="speed" :clock-label="clockLabel" :play="play" :pause="pause" :step="step"


### PR DESCRIPTION
## Summary
- add AudioManager module to centralize background music handling
- remove duplicate `<audio>` tags and use AudioManager in simulation
- initialize AudioManager on app startup

## Testing
- `npm test` *(fails: expected spy to be called with arguments [45], [12])*

------
https://chatgpt.com/codex/tasks/task_e_68aade8a95d48332aa8387efa3f056d0